### PR TITLE
[system] manage netboot_enabled on system creation

### DIFF
--- a/lib/puppet/provider/cobbler_system/ruby.rb
+++ b/lib/puppet/provider/cobbler_system/ruby.rb
@@ -63,6 +63,7 @@ Puppet::Type.type(:cobbler_system).provide(:ruby) do
     # set properties as they are not set by defaut
     properties = [
       "hostname",
+      "netboot_enabled",
       "redhat_management_server",
       "redhat_management_key",
       "server",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -201,9 +201,9 @@ class cobbler (
     service_enable => $service_enable,
   }
 
-  Anchor['cobbler::begin'] ->
-  Class['cobbler::install'] ->
-  Class['cobbler::config'] ~>
-  Class['cobbler::service'] ->
-  Anchor['cobbler::end']
+  Anchor['cobbler::begin']
+  -> Class['cobbler::install']
+  -> Class['cobbler::config']
+  ~> Class['cobbler::service']
+  -> Anchor['cobbler::end']
 }


### PR DESCRIPTION
Hi,

I've encountered with an issue, when `netboot_enabled` parameter was not applied on first run of puppet.
The patch fixes this issue.

UPD: also fixes tests for repo