### PR TITLE
cobbler profile enable gpxe

### DIFF
--- a/lib/puppet/provider/cobbler_profile/ruby.rb
+++ b/lib/puppet/provider/cobbler_profile/ruby.rb
@@ -28,6 +28,7 @@ Puppet::Type.type(:cobbler_profile).provide(:ruby) do
         :ensure                => :present,
         :distro                => profile["distro"],
         :dhcp_tag              => profile["dhcp_tag"],
+        :enable_gpxe           => profile["enable_gpxe"],
         :name_servers          => profile["name_servers"],
         :name_servers_search   => profile["name_servers_search"],
         :kickstart             => profile["kickstart"],
@@ -57,7 +58,7 @@ Puppet::Type.type(:cobbler_profile).provide(:ruby) do
 
   def create
     # To add a profile only name and distro is required
-    cobbler( 
+    cobbler(
             [
               "profile",
               "add",
@@ -69,6 +70,7 @@ Puppet::Type.type(:cobbler_profile).provide(:ruby) do
     properties = [
       "distro",
       "dhcp_tag",
+      "enable_gpxe",
       "name_servers",
       "name_servers_search",
       "kickstart",
@@ -142,6 +144,10 @@ Puppet::Type.type(:cobbler_profile).provide(:ruby) do
 
   def dhcp_tag=(value)
     self.set_field("dhcp_tag", value)
+  end
+
+  def enable_gpxe=(value)
+    self.set_field("enable_gpxe", value)
   end
 
   def name_servers=(value)

--- a/lib/puppet/type/cobbler_profile.rb
+++ b/lib/puppet/type/cobbler_profile.rb
@@ -49,8 +49,8 @@ Puppet::Type.newtype(:cobbler_profile) do
   newproperty(:enable_gpxe) do
     desc 'Enable gpxe functionality for gPXE/iPXE booting'
     validate do |value|
-      unless value.is_a? Integer
-        raise ArgumentError, "Enable_gpxe parameter accepts only integer value"
+      unless value.is_a?(TrueClass) || value.is_a?(FalseClass)
+        raise ArgumentError, "Enable_gpxe parameter accepts true or false value"
       end
     end
   end

--- a/lib/puppet/type/cobbler_profile.rb
+++ b/lib/puppet/type/cobbler_profile.rb
@@ -20,7 +20,7 @@ Puppet::Type.newtype(:cobbler_profile) do
     desc "Path to kickstart template"
     validate do |value|
       if value
-        unless Pathname.new(value).absolute? 
+        unless Pathname.new(value).absolute?
           raise ArgumentError, "%s is not a valid path" % value
         end
       end
@@ -44,6 +44,15 @@ Puppet::Type.newtype(:cobbler_profile) do
   newproperty(:dhcp_tag) do
     desc 'DHCP tags for multiple networks usage'
     defaultto('default')
+  end
+
+  newproperty(:enable_gpxe) do
+    desc 'Enable gpxe functionality for gPXE/iPXE booting'
+    validate do |value|
+      unless value.is_a? Integer
+        raise ArgumentError, "Enable_gpxe parameter accepts only integer value"
+      end
+    end
   end
 
   newproperty(:name_servers, :array_matching => :all) do

--- a/spec/unit/puppet/type/cobbler_profile_spec.rb
+++ b/spec/unit/puppet/type/cobbler_profile_spec.rb
@@ -136,6 +136,7 @@ describe Puppet::Type.type(:cobbler_profile) do
       end
     end
     [
+      :enable_gpxe,
       :virt_cpus,
       :virt_ram
     ].each do |param|


### PR DESCRIPTION
I am working on building out an ipxe deployment environment, with cobbler as the backend. To use cobbler's gpxe scripts, you need to enable gpxe either in the "profile" or in the "system" entry. This change allows you to enforce enabling gpxe at the "profile" level.

Ruby is not my strong suit, really just following existing patterns. But this worked in testing on cobbler 2.8.3 (newest official release).